### PR TITLE
Rename GroupID to fish.payara.extensions.notifiers

### DIFF
--- a/example-notifier-console-plugin/pom.xml
+++ b/example-notifier-console-plugin/pom.xml
@@ -42,7 +42,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>fish.payara.extras.notifiers</groupId>
+        <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>

--- a/example-notifier-core/pom.xml
+++ b/example-notifier-core/pom.xml
@@ -42,7 +42,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>fish.payara.extras.notifiers</groupId>
+        <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>fish.payara.extras.notifiers</groupId>
+    <groupId>fish.payara.extensions.notifiers</groupId>
     <artifactId>notifiers-parent</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>


### PR DESCRIPTION
If the Group ID is unique and identifiable as part of the new extensions, it'll be easier to group all of our extensions together.