### PR TITLE
FISH-1288: Flight Recorder Notifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ target/
 .classpath
 .factorypath
 .vscode/
+*.iml
+.idea
+.DS_Store

--- a/jfr-notifier-console-plugin/pom.xml
+++ b/jfr-notifier-console-plugin/pom.xml
@@ -48,7 +48,7 @@
         <version>1.0</version>
     </parent>
     <artifactId>jfr-notifier-console-plugin</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0</version>
     <packaging>glassfish-jar</packaging>
 
 

--- a/jfr-notifier-console-plugin/pom.xml
+++ b/jfr-notifier-console-plugin/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+  Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+
+  The contents of this file are subject to the terms of either the GNU
+  General Public License Version 2 only ("GPL") or the Common Development
+  and Distribution License("CDDL") (collectively, the "License").  You
+  may not use this file except in compliance with the License.  You can
+  obtain a copy of the License at
+  https://github.com/payara/Payara/blob/master/LICENSE.txt
+  See the License for the specific
+  language governing permissions and limitations under the License.
+
+  When distributing the software, include this License Header Notice in each
+  file and include the License file at glassfish/legal/LICENSE.txt.
+
+  GPL Classpath Exception:
+  The Payara Foundation designates this particular file as subject to the "Classpath"
+  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  file that accompanied this code.
+
+  Modifications:
+  If applicable, add the following below the License Header, with the fields
+  enclosed by brackets [] replaced by your own identifying information:
+  "Portions Copyright [year] [name of copyright owner]"
+
+  Contributor(s):
+  If you wish your version of this file to be governed by only the CDDL or
+  only the GPL Version 2, indicate your decision by adding "[Contributor]
+  elects to include this software in this distribution under the [CDDL or GPL
+  Version 2] license."  If you don't indicate a single choice of license, a
+  recipient has the option to distribute your version of this file under
+  either the CDDL, the GPL Version 2 or to extend the choice of license to
+  its licensees as provided above.  However, if you add GPL Version 2 code
+  and therefore, elected the GPL Version 2 license, then the option applies
+  only if the new code is made subject to such option by the copyright
+  holder.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>fish.payara.extensions.notifiers</groupId>
+        <artifactId>notifiers-parent</artifactId>
+        <version>1.0</version>
+    </parent>
+    <artifactId>jfr-notifier-console-plugin</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>glassfish-jar</packaging>
+
+
+    <name>JFR Notifier Console Plugin</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>fish.payara.server.internal.admingui</groupId>
+            <artifactId>console-plugin-service</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/jfr-notifier-console-plugin/src/main/java/fish/payara/admingui/notifier/jfr/JFRNotifierPlugin.java
+++ b/jfr-notifier-console-plugin/src/main/java/fish/payara/admingui/notifier/jfr/JFRNotifierPlugin.java
@@ -1,0 +1,53 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.admingui.notifier.jfr;
+
+import java.net.URL;
+import org.glassfish.api.admingui.ConsoleProvider;
+import org.jvnet.hk2.annotations.Service;
+
+@Service
+public class JFRNotifierPlugin implements ConsoleProvider {
+    
+    @Override
+    public URL getConfiguration() {
+        return null;
+    }
+}

--- a/jfr-notifier-console-plugin/src/main/resources/META-INF/admingui/console-config.xml
+++ b/jfr-notifier-console-plugin/src/main/resources/META-INF/admingui/console-config.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+  Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+
+  The contents of this file are subject to the terms of either the GNU
+  General Public License Version 2 only ("GPL") or the Common Development
+  and Distribution License("CDDL") (collectively, the "License").  You
+  may not use this file except in compliance with the License.  You can
+  obtain a copy of the License at
+  https://github.com/payara/Payara/blob/master/LICENSE.txt
+  See the License for the specific
+  language governing permissions and limitations under the License.
+
+  When distributing the software, include this License Header Notice in each
+  file and include the License file at glassfish/legal/LICENSE.txt.
+
+  GPL Classpath Exception:
+  The Payara Foundation designates this particular file as subject to the "Classpath"
+  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  file that accompanied this code.
+
+  Modifications:
+  If applicable, add the following below the License Header, with the fields
+  enclosed by brackets [] replaced by your own identifying information:
+  "Portions Copyright [year] [name of copyright owner]"
+
+  Contributor(s):
+  If you wish your version of this file to be governed by only the CDDL or
+  only the GPL Version 2, indicate your decision by adding "[Contributor]
+  elects to include this software in this distribution under the [CDDL or GPL
+  Version 2] license."  If you don't indicate a single choice of license, a
+  recipient has the option to distribute your version of this file under
+  either the CDDL, the GPL Version 2 or to extend the choice of license to
+  its licensees as provided above.  However, if you add GPL Version 2 code
+  and therefore, elected the GPL Version 2 license, then the option applies
+  only if the new code is made subject to such option by the copyright
+  holder.
+ -->
+<console-config id="jfrNotifier">
+    <integration-point
+        id="jfrNotifier"
+        type="fish.payara.admingui:notifierTab"
+        priority="40"
+        parentId="notificationConfigTabs"
+        content="jfr/jfrNotifierTabs.jsf"
+    />
+</console-config>

--- a/jfr-notifier-console-plugin/src/main/resources/fish/payara/admingui/notifier/jfr/Strings.properties
+++ b/jfr-notifier-console-plugin/src/main/resources/fish/payara/admingui/notifier/jfr/Strings.properties
@@ -1,0 +1,48 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/master/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+
+notifier.jfr.tabs.tabText=Flight Recorder
+notifier.jfr.tabs.tabToolTip=Flight Recorder Notifier Configuration
+notifier.jfr.configuration.pageTitle=Flight Recorder Notifier Configuration
+notifier.jfr.configuration.pageHelpText=Enable and configure the Flight Recorder Notifier
+notifier.jfr.configuration.enabledLabel=Enabled
+notifier.jfr.configuration.enabledLabelHelpText=Enables/Disables the Flight Recorder Notifier
+notifier.jfr.configuration.categoryLabel=Filter Health Check Name
+notifier.jfr.configuration.categoryLabelHelpText=Comma separated list of names to send or * for all.
+notifier.jfr.msg.success=Success
+notifier.jfr.buttons.test=Test

--- a/jfr-notifier-console-plugin/src/main/resources/jfr/jfrNotifierConfiguration.jsf
+++ b/jfr-notifier-console-plugin/src/main/resources/jfr/jfrNotifierConfiguration.jsf
@@ -1,0 +1,130 @@
+<!--
+  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+  Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+
+  The contents of this file are subject to the terms of either the GNU
+  General Public License Version 2 only ("GPL") or the Common Development
+  and Distribution License("CDDL") (collectively, the "License").  You
+  may not use this file except in compliance with the License.  You can
+  obtain a copy of the License at
+  https://github.com/payara/Payara/blob/master/LICENSE.txt
+  See the License for the specific
+  language governing permissions and limitations under the License.
+
+  When distributing the software, include this License Header Notice in each
+  file and include the License file at glassfish/legal/LICENSE.txt.
+
+  GPL Classpath Exception:
+  The Payara Foundation designates this particular file as subject to the "Classpath"
+  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  file that accompanied this code.
+
+  Modifications:
+  If applicable, add the following below the License Header, with the fields
+  enclosed by brackets [] replaced by your own identifying information:
+  "Portions Copyright [year] [name of copyright owner]"
+
+  Contributor(s):
+  If you wish your version of this file to be governed by only the CDDL or
+  only the GPL Version 2, indicate your decision by adding "[Contributor]
+  elects to include this software in this distribution under the [CDDL or GPL
+  Version 2] license."  If you don't indicate a single choice of license, a
+  recipient has the option to distribute your version of this file under
+  either the CDDL, the GPL Version 2 or to extend the choice of license to
+  its licensees as provided above.  However, if you add GPL Version 2 code
+  and therefore, elected the GPL Version 2 license, then the option applies
+  only if the new code is made subject to such option by the copyright
+  holder.
+ -->
+<!initPage
+    setResourceBundle(key="i18nc" bundle="org.glassfish.common.admingui.Strings");
+    setResourceBundle(key="i18ncs" bundle="org.glassfish.cluster.admingui.Strings");
+    setResourceBundle(key="i18nexn" bundle="fish.payara.admingui.notifier.jfr.Strings");
+    setResourceBundle(key="i18nn" bundle="fish.payara.admingui.extras.Strings");
+    />
+<!composition template="/templates/default.layout"  guiTitle="$resource{i18nexn.notifier.jfr.configuration.pageTitle}"  >
+<!define name="content">
+<event>
+    <!beforeCreate 
+        getRequestValue(key="configName" value="#{pageSession.configName}" );
+        createMap(result="#{pageSession.attrsMap}")
+        mapPut(map="#{pageSession.attrsMap}" key="target" value="#{pageSession.configName}");
+        gf.restRequest(endpoint="#{sessionScope.NOTIFICATION_CONFIG_URL}/get-jfr-notifier-configuration?target=#{pageSession.configName}"
+                method="GET" result="#{requestScope.resp}");
+        setPageSessionAttribute(key="valueMap", value="#{requestScope.resp.data.extraProperties.notifierConfiguration}");
+        mapPut(map="#{pageSession.valueMap}" key="target" value="#{pageSession.configName}");
+        setPageSessionAttribute(key="convertToFalseList", value={"enabled", "noisy", "dynamic"});
+        
+        if (#{pageSession.valueMap['enabled']}=true) {
+            setPageSessionAttribute(key="enabledSelected", value="true");
+        }
+        if (#{pageSession.valueMap['noisy']}=true) {
+			setPageSessionAttribute(key="noisy", value="true");
+		}	
+        setPageSessionAttribute(key="dynamic", value="true");
+    /> 
+</event>
+<sun:form id="propertyForm">
+#include "/common/shared/alertMsg_1.inc"
+#include "/payaraExtras/notification/notificationConfigTabs.inc"
+    <sun:title id="propertyContentPage" title="$resource{i18nexn.notifier.jfr.configuration.pageTitle}"
+               helpText="$resource{i18nexn.notifier.jfr.configuration.pageHelpText}" >
+        <sun:button id = "test" text="$resource{i18nexn.notifier.jfr.buttons.test}">
+            <!command 
+                createMap(result="#{pageSession.attrsMap}");
+                mapPut(map="#{pageSession.attrsMap}" key="notifiers" value="jfr-notifier");
+                gf.restRequest(endpoint="#{sessionScope.NOTIFICATION_CONFIG_URL}/test-notifier-configuration" method="GET" 
+                    attrs="#{pageSession.attrsMap}" result="#{requestScope.result}");
+                if ("#{requestScope.result.data['exit_code']} = SUCCESS") {
+                    prepareAlertMsg(summary="$resource{i18nexn.notifier.jfr.msg.success}", type="success");
+                } 
+                />
+        </sun:button>
+            <!facet pageButtonsTop>
+            <sun:panelGroup id="topButtons">
+                <sun:button id="saveButton"  text="$resource{i18n.button.Save}"
+                        onClick="if (guiValidate('#{reqMsg}','#{reqInt}','#{reqPort}')) submitAndDisable(this, '$resource{i18n.button.Processing}'); return false;" >
+                    <!command
+                        mapPut(map="#{pageSession.valueMap}" key="enabled" value="#{pageSession.enabledSelected}");
+						mapPut(map="#{pageSession.valueMap}" key="noisy" value="#{pageSession.noisy}");
+                        mapPut(map="#{pageSession.valueMap}" key="dynamic" value="#{pageSession.dynamic}");
+                        prepareSuccessfulMsg();
+                        gf.updateEntity(endpoint="#{sessionScope.NOTIFICATION_CONFIG_URL}/set-jfr-notifier-configuration"
+                                attrs="#{pageSession.valueMap}" convertToFalse="#{pageSession.convertToFalseList}");
+                        />
+                </sun:button>
+            </sun:panelGroup>
+        </facet>
+    </sun:title>
+
+    <sun:propertySheet id="propertySheet">
+#include "/common/shared/configNameSection.inc"
+        <sun:propertySheetSection id="jfrNotifierProperties">
+            <sun:property id="enabledProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" 
+                          label="$resource{i18nexn.notifier.jfr.configuration.enabledLabel}"
+                          helpText="$resource{i18nexn.notifier.jfr.configuration.enabledLabelHelpText}">
+                <sun:checkbox id="enabledProp" selected="#{pageSession.enabledSelected}" selectedValue="true" />
+            </sun:property>
+            <sun:property id="noisy" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" 
+                          label="$resource{i18nn.notification.configuration.notifier.noisyLabel}"  
+                          helpText="$resource{i18nn.notification.configuration.notifier.noisyLabelHelpText}">
+                <sun:checkbox id="noisy" selected="#{pageSession.noisy}" selectedValue="true" />
+            </sun:property>
+            <sun:property id="dynamic" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" 
+                          label="$resource{i18nn.notification.configuration.dynamic}"  
+                          helpText="$resource{i18nn.notification.configuration.notifier.dynamicHelp}">
+                <sun:checkbox id="dynamic" selected="#{pageSession.dynamic}" selectedValue="true" />
+            </sun:property>
+            <sun:property id="filterNamesValueProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"
+                          label="$resource{i18nexn.notifier.jfr.configuration.categoryLabel}"
+                          helpText="$resource{i18nexn.notifier.jfr.configuration.categoryLabelHelpText}">
+                <sun:textField id="namesField"  maxLength="255"
+                               text="#{pageSession.valueMap['filternames']}" styleClass="string"
+                               required="#{true}"/>
+            </sun:property>
+        </sun:propertySheetSection>
+    </sun:propertySheet>
+</sun:form>
+</define>
+</composition>

--- a/jfr-notifier-console-plugin/src/main/resources/jfr/jfrNotifierTabs.jsf
+++ b/jfr-notifier-console-plugin/src/main/resources/jfr/jfrNotifierTabs.jsf
@@ -1,0 +1,51 @@
+<!--
+  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+  Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+
+  The contents of this file are subject to the terms of either the GNU
+  General Public License Version 2 only ("GPL") or the Common Development
+  and Distribution License("CDDL") (collectively, the "License").  You
+  may not use this file except in compliance with the License.  You can
+  obtain a copy of the License at
+  https://github.com/payara/Payara/blob/master/LICENSE.txt
+  See the License for the specific
+  language governing permissions and limitations under the License.
+
+  When distributing the software, include this License Header Notice in each
+  file and include the License file at glassfish/legal/LICENSE.txt.
+
+  GPL Classpath Exception:
+  The Payara Foundation designates this particular file as subject to the "Classpath"
+  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  file that accompanied this code.
+
+  Modifications:
+  If applicable, add the following below the License Header, with the fields
+  enclosed by brackets [] replaced by your own identifying information:
+  "Portions Copyright [year] [name of copyright owner]"
+
+  Contributor(s):
+  If you wish your version of this file to be governed by only the CDDL or
+  only the GPL Version 2, indicate your decision by adding "[Contributor]
+  elects to include this software in this distribution under the [CDDL or GPL
+  Version 2] license."  If you don't indicate a single choice of license, a
+  recipient has the option to distribute your version of this file under
+  either the CDDL, the GPL Version 2 or to extend the choice of license to
+  its licensees as provided above.  However, if you add GPL Version 2 code
+  and therefore, elected the GPL Version 2 license, then the option applies
+  only if the new code is made subject to such option by the copyright
+  holder.
+ -->
+<sun:tab id="jfrNotifierTab" immediate="true" text="$resource{i18nexn.notifier.jfr.tabs.tabText}"
+         toolTip="$resource{i18nexn.notifier.jfr.tabs.tabToolTip}">
+    <!beforeCreate
+        setResourceBundle(key="i18nexn" bundle="fish.payara.admingui.notifier.jfr.Strings");
+        setResourceBundle(key="i18nc" bundle="org.glassfish.common.admingui.Strings");
+    />
+    <!command
+        setSessionAttribute(key="notificationConfigTab" value="jfrNotifierTab");
+        gf.redirect(page="#{request.contextPath}/jfrNotifier/jfr/jfrNotifierConfiguration.jsf?configName=#{pageSession.configName}");
+    />
+</sun:tab>
+

--- a/jfr-notifier-core/README.md
+++ b/jfr-notifier-core/README.md
@@ -1,0 +1,14 @@
+# Flight Recorder Notifier
+
+This module contains the core of The Java Flight Recorder Notifier. It propagates the Notification Events to the Flight Recorder Subsystem of the JVM.
+
+It requires JDK 11 (or Zulu JDK 8 with the Flight Recorder backported) and the changes to the `osgi.properties` file as described in https://github.com/payara/Payara/pull/5180 (available in 5.2021.3 by default)
+
+Adding the jar file to the `modules` directory of Payara Server makes
+- a notifier called `jfr-notifier` available as notification channel for Health Checks, Request Tracing and Asadmin Audit.
+- defines the `set-jfr-notifier-configuration` Asadmin CLI command to activate and configure the notifier.
+- defines the `get-jfr-notifier-configuration` Asadmin CLI command to show the notifier configuration.
+
+The notifier has 1 configuration parameter (`filterNames`) that can be used to 'filter' some notification events.  By default, the value contains `*` and all events are sent to the Flight Recorder. It can contain a comma-separated list of the Health check names that need to be sent like `CONP,STUCK`  (Connection Pool and Stuck Threads health check).
+
+The Web Console plugin is available within module `jfr-notifier-console-plugin`.

--- a/jfr-notifier-core/pom.xml
+++ b/jfr-notifier-core/pom.xml
@@ -48,7 +48,7 @@
         <version>1.0</version>
     </parent>
     <artifactId>jfr-notifier-core</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0</version>
     <packaging>glassfish-jar</packaging>
 
     <name>JFR Notifier Implementation</name>

--- a/jfr-notifier-core/pom.xml
+++ b/jfr-notifier-core/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+  Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+
+  The contents of this file are subject to the terms of either the GNU
+  General Public License Version 2 only ("GPL") or the Common Development
+  and Distribution License("CDDL") (collectively, the "License").  You
+  may not use this file except in compliance with the License.  You can
+  obtain a copy of the License at
+  https://github.com/payara/Payara/blob/master/LICENSE.txt
+  See the License for the specific
+  language governing permissions and limitations under the License.
+
+  When distributing the software, include this License Header Notice in each
+  file and include the License file at glassfish/legal/LICENSE.txt.
+
+  GPL Classpath Exception:
+  The Payara Foundation designates this particular file as subject to the "Classpath"
+  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  file that accompanied this code.
+
+  Modifications:
+  If applicable, add the following below the License Header, with the fields
+  enclosed by brackets [] replaced by your own identifying information:
+  "Portions Copyright [year] [name of copyright owner]"
+
+  Contributor(s):
+  If you wish your version of this file to be governed by only the CDDL or
+  only the GPL Version 2, indicate your decision by adding "[Contributor]
+  elects to include this software in this distribution under the [CDDL or GPL
+  Version 2] license."  If you don't indicate a single choice of license, a
+  recipient has the option to distribute your version of this file under
+  either the CDDL, the GPL Version 2 or to extend the choice of license to
+  its licensees as provided above.  However, if you add GPL Version 2 code
+  and therefore, elected the GPL Version 2 license, then the option applies
+  only if the new code is made subject to such option by the copyright
+  holder.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>fish.payara.extensions.notifiers</groupId>
+        <artifactId>notifiers-parent</artifactId>
+        <version>1.0</version>
+    </parent>
+    <artifactId>jfr-notifier-core</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>glassfish-jar</packaging>
+
+    <name>JFR Notifier Implementation</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>fish.payara.server.internal.common</groupId>
+            <artifactId>internal-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.api</groupId>
+            <artifactId>payara-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/jfr-notifier-core/src/main/java/fish/payara/extensions/notifiers/jfr/GetJFRNotifierConfigurationCommand.java
+++ b/jfr-notifier-core/src/main/java/fish/payara/extensions/notifiers/jfr/GetJFRNotifierConfigurationCommand.java
@@ -1,0 +1,84 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.extensions.notifiers.jfr;
+
+import java.util.Map;
+
+import org.glassfish.api.admin.CommandLock;
+import org.glassfish.api.admin.ExecuteOn;
+import org.glassfish.api.admin.RestEndpoint;
+import org.glassfish.api.admin.RestEndpoints;
+import org.glassfish.api.admin.RuntimeType;
+import org.glassfish.config.support.CommandTarget;
+import org.glassfish.config.support.TargetType;
+import org.glassfish.hk2.api.PerLookup;
+import org.jvnet.hk2.annotations.Service;
+
+import fish.payara.internal.notification.admin.BaseGetNotifierConfigurationCommand;
+import fish.payara.internal.notification.admin.NotificationServiceConfiguration;
+
+/**
+ * @author mertcaliskan
+ */
+@Service(name = "get-jfr-notifier-configuration")
+@PerLookup
+@CommandLock(CommandLock.LockType.NONE)
+@ExecuteOn({RuntimeType.DAS, RuntimeType.INSTANCE})
+@TargetType(value = {CommandTarget.DAS, CommandTarget.STANDALONE_INSTANCE, CommandTarget.CLUSTER, CommandTarget.CLUSTERED_INSTANCE, CommandTarget.CONFIG})
+@RestEndpoints({
+        @RestEndpoint(configBean = NotificationServiceConfiguration.class,
+                opType = RestEndpoint.OpType.GET,
+                path = "get-jfr-notifier-configuration",
+                description = "Get Flight Recorder Notifier Configuration")
+})
+public class GetJFRNotifierConfigurationCommand extends BaseGetNotifierConfigurationCommand<JFRNotifierConfiguration> {
+    
+    @Override
+    protected Map<String, Object> getNotifierConfiguration(JFRNotifierConfiguration configuration) {
+        Map<String, Object> map = super.getNotifierConfiguration(configuration);
+
+        if (configuration != null) {
+            map.put("filterNames", configuration.getFilterNames());
+        }
+
+        return map;
+    }
+
+}

--- a/jfr-notifier-core/src/main/java/fish/payara/extensions/notifiers/jfr/JFRNotifier.java
+++ b/jfr-notifier-core/src/main/java/fish/payara/extensions/notifiers/jfr/JFRNotifier.java
@@ -1,0 +1,158 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.extensions.notifiers.jfr;
+
+import fish.payara.internal.notification.PayaraConfiguredNotifier;
+import fish.payara.internal.notification.PayaraNotification;
+import fish.payara.notification.healthcheck.HealthCheckNotificationData;
+import fish.payara.notification.requesttracing.RequestTracingNotificationData;
+import jdk.jfr.*;
+import org.jvnet.hk2.annotations.Service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Logger;
+
+@Service(name = "jfr-notifier")
+public class JFRNotifier extends PayaraConfiguredNotifier<JFRNotifierConfiguration> {
+
+    private Logger logger;
+
+    private List<ValueDescriptor> fields;
+
+    @Override
+    public void handleNotification(PayaraNotification notification) {
+        if (!"*".equals(configuration.getFilterNames())) {
+            if (!configuration.getFilterNames().contains(notification.getSubject())) {
+                // Not wanted
+                return;
+            }
+        }
+
+        String[] category = {"Payara", notification.getSubject()};
+        List<AnnotationElement> eventAnnotations = new ArrayList<>();
+
+        eventAnnotations.add(new AnnotationElement(Name.class, generateFlightRecorderNameValue(notification)));
+        eventAnnotations.add(new AnnotationElement(Label.class, "Payara JFR Notification"));
+        eventAnnotations.add(new AnnotationElement(Description.class, "JFR Notification"));
+        eventAnnotations.add(new AnnotationElement(Category.class, category));
+
+        EventFactory eventFactory = EventFactory.create(eventAnnotations, fields);
+
+        boolean knownData = false;
+        if (notification.getData() instanceof HealthCheckNotificationData) {
+            HealthCheckNotificationData data = (HealthCheckNotificationData) notification.getData();
+
+            handleHealthCheckData(eventFactory, notification.getServerName(), data);
+            knownData = true;
+        }
+        if (notification.getData() instanceof RequestTracingNotificationData) {
+            RequestTracingNotificationData data = (RequestTracingNotificationData) notification.getData();
+            handleRequestTracingData(eventFactory, notification.getServerName(), data);
+            knownData = true;
+        }
+        if (!knownData) {
+            String dataClassName = notification.getData() == null ? "null" : notification.getData().getClass().getName();
+            logger.warning(String.format("Unknown Notification Data received; data class name '%s', message %s"
+                    , dataClassName, notification.getMessage()));
+        }
+
+
+    }
+
+    private void handleRequestTracingData(EventFactory eventFactory, String serverName, RequestTracingNotificationData data) {
+        Event event = eventFactory.newEvent();
+        event.set(0, serverName);
+
+        event.set(1, "REQUEST TRACE");
+        event.set(2, data.getRequestTrace().toString());
+        event.commit();
+    }
+
+    private void handleHealthCheckData(EventFactory eventFactory, String serverName, HealthCheckNotificationData data) {
+        if (data.getEntries() == null || data.getEntries().isEmpty()) {
+            Event event = eventFactory.newEvent();
+            event.set(0, serverName);
+            event.set(1, "???");
+            event.set(2, "Empty HealthCheckResultEntry");
+            event.commit();
+
+        } else {
+            for (int i = 0; i < data.getEntries().size(); i++) {
+                Event event = eventFactory.newEvent();
+                event.set(0, serverName);
+                event.set(1, data.getEntries().get(i).getStatus().name());
+                event.set(2, data.getEntries().get(i).getMessage());
+                event.commit();
+            }
+        }
+    }
+
+    private String generateFlightRecorderNameValue(PayaraNotification notification) {
+        String suffix = notification.getSubject();
+        // This needs to be a valid Java identifier
+        suffix = suffix.replaceAll(" ", "_")
+                .replaceAll(":", "_")
+                .replaceAll("-", "_");
+        return "payara." + suffix;
+    }
+
+    @Override
+    public void bootstrap() {
+
+        fields = new ArrayList<>();
+        List<AnnotationElement> serverNameAnnotations = Collections.singletonList(new AnnotationElement(Label.class, "Server Name"));
+        fields.add(new ValueDescriptor(String.class, "serverName", serverNameAnnotations));
+        List<AnnotationElement> statusAnnotations = Collections.singletonList(new AnnotationElement(Label.class, "Status"));
+        fields.add(new ValueDescriptor(String.class, "status", statusAnnotations));
+        List<AnnotationElement> messageAnnotations = Collections.singletonList(new AnnotationElement(Label.class, "Message"));
+        fields.add(new ValueDescriptor(String.class, "message", messageAnnotations));
+
+        logger = Logger.getLogger(JFRNotifier.class.getName());
+        logger.info("Starting JFR notifier");
+    }
+
+    @Override
+    public void destroy() {
+        logger.info("Destroying JFR notifier");
+    }
+
+}

--- a/jfr-notifier-core/src/main/java/fish/payara/extensions/notifiers/jfr/JFRNotifierConfiguration.java
+++ b/jfr-notifier-core/src/main/java/fish/payara/extensions/notifiers/jfr/JFRNotifierConfiguration.java
@@ -1,0 +1,56 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.extensions.notifiers.jfr;
+
+import java.beans.PropertyVetoException;
+
+import org.jvnet.hk2.config.Attribute;
+import org.jvnet.hk2.config.Configured;
+
+import fish.payara.internal.notification.PayaraNotifierConfiguration;
+
+@Configured
+public interface JFRNotifierConfiguration extends PayaraNotifierConfiguration {
+
+    @Attribute( dataType = String.class)
+    String getFilterNames();
+    void setFilterNames(String value) throws PropertyVetoException;
+    
+}

--- a/jfr-notifier-core/src/main/java/fish/payara/extensions/notifiers/jfr/SetJFRNotifierConfigurationCommand.java
+++ b/jfr-notifier-core/src/main/java/fish/payara/extensions/notifiers/jfr/SetJFRNotifierConfigurationCommand.java
@@ -1,0 +1,85 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.extensions.notifiers.jfr;
+
+import java.beans.PropertyVetoException;
+
+import org.glassfish.api.Param;
+import org.glassfish.api.admin.CommandLock;
+import org.glassfish.api.admin.ExecuteOn;
+import org.glassfish.api.admin.RestEndpoint;
+import org.glassfish.api.admin.RestEndpoints;
+import org.glassfish.api.admin.RuntimeType;
+import org.glassfish.config.support.CommandTarget;
+import org.glassfish.config.support.TargetType;
+import org.glassfish.hk2.api.PerLookup;
+import org.jvnet.hk2.annotations.Service;
+
+import fish.payara.internal.notification.admin.BaseSetNotifierConfigurationCommand;
+import fish.payara.internal.notification.admin.NotificationServiceConfiguration;
+
+/**
+ *
+ */
+@Service(name = "set-jfr-notifier-configuration")
+@PerLookup
+@CommandLock(CommandLock.LockType.NONE)
+@ExecuteOn({RuntimeType.DAS, RuntimeType.INSTANCE})
+@TargetType(value = {CommandTarget.DAS, CommandTarget.STANDALONE_INSTANCE, CommandTarget.CLUSTER, CommandTarget.CLUSTERED_INSTANCE, CommandTarget.CONFIG})
+@RestEndpoints({
+        @RestEndpoint(configBean = NotificationServiceConfiguration.class,
+                opType = RestEndpoint.OpType.POST,
+                path = "set-jfr-notifier-configuration",
+                description = "Configures Flight Recorder Notification Service")
+})
+public class SetJFRNotifierConfigurationCommand extends BaseSetNotifierConfigurationCommand<JFRNotifierConfiguration> {
+
+    @Param(name = "filternames", optional = true, defaultValue = "*")
+    private String filterNames;
+
+    @Override
+    protected void applyValues(JFRNotifierConfiguration configuration) throws PropertyVetoException {
+        super.applyValues(configuration);
+        if (this.filterNames != null) {
+            configuration.setFilterNames(this.filterNames);
+        }
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <!--
   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-  Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+  Copyright (c) [2020-2021] Payara Foundation and/or its affiliates. All rights reserved.
 
   The contents of this file are subject to the terms of either the GNU
   General Public License Version 2 only ("GPL") or the Common Development
@@ -100,6 +100,12 @@
                 <artifactId>jakarta.jakartaee-api</artifactId>
                 <version>8.0.0</version>
                 <optional>true</optional>
+            </dependency>
+            <dependency>
+                <groupId>fish.payara.api</groupId>
+                <artifactId>payara-api</artifactId>
+                <version>${payara.version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
@@ -260,6 +266,11 @@
                         <outputDirectory>${project.build.directory}</outputDirectory>
                     </configuration>
                 </plugin>
+                <plugin>
+                   <groupId>org.apache.maven.plugins</groupId>
+                   <artifactId>maven-resources-plugin</artifactId>
+                   <version>2.4</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
@@ -299,4 +310,16 @@
             <url>https://nexus.payara.fish/repository/payara-artifacts/</url>
         </repository>
     </distributionManagement>
+    <profiles>
+        <profile>
+            <id>java11</id>
+            <activation>
+                <jdk>11</jdk>
+            </activation>
+            <modules>
+                <module>jfr-notifier-core</module>
+                <module>jfr-notifier-console-plugin</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
## Description
A notifier that send the Notification Events to Flight Recorder.

Each Flight Recorder event is in the 'package'  Payara \ `type`.  where `type` is the code of the healthcheck.

Creates a Flight Record with following fields
- server name
- status
- message

## Important Info
### Blockers

Can only be build and used on JDK 11.

## Testing

### Testing Performed

`get-jfr-notifier-configuration` asadmin command
`set-jfr-notifier-configuration` asadmin command
WebConsole plugin (activate, test button, ...)

supports 
- Health check notification events.
- Request Tracing events
- Asadmin Audit events

### Testing Environment

Zulu11.45+27-CA (build 11.0.10+9-LTS, mixed mode) on Mac 11.2.3 with Maven 3.6.3

## Documentation

https://github.com/payara/Notifiers/pull/17/files#diff-f115a9e69f73702c31d07f026dd60ca5ad85e461fb2ee884ea1bc6748a68ebed

## Notes for Reviewers
