### PR TITLE
FISH-6263 xmpp-notifier-core 1.1 Release (Attempt 4)

### DIFF
--- a/datadog-notifier-console-plugin-l10n/pom.xml
+++ b/datadog-notifier-console-plugin-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise-SNAPSHOT</version>
+        <version>1.1-enterprise</version>
     </parent>
 
     <artifactId>datadog-notifier-console-plugin-l10n</artifactId>

--- a/datadog-notifier-console-plugin-l10n/pom.xml
+++ b/datadog-notifier-console-plugin-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise</version>
+        <version>1.2-enterprise-SNAPSHOT</version>
     </parent>
 
     <artifactId>datadog-notifier-console-plugin-l10n</artifactId>

--- a/datadog-notifier-console-plugin/pom.xml
+++ b/datadog-notifier-console-plugin/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise-SNAPSHOT</version>
+        <version>1.1-enterprise</version>
     </parent>
 
     <artifactId>datadog-notifier-console-plugin</artifactId>

--- a/datadog-notifier-console-plugin/pom.xml
+++ b/datadog-notifier-console-plugin/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise</version>
+        <version>1.2-enterprise-SNAPSHOT</version>
     </parent>
 
     <artifactId>datadog-notifier-console-plugin</artifactId>

--- a/datadog-notifier-core/pom.xml
+++ b/datadog-notifier-core/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise</version>
+        <version>1.2-enterprise-SNAPSHOT</version>
     </parent>
 
     <artifactId>datadog-notifier-core</artifactId>

--- a/datadog-notifier-core/pom.xml
+++ b/datadog-notifier-core/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise-SNAPSHOT</version>
+        <version>1.1-enterprise</version>
     </parent>
 
     <artifactId>datadog-notifier-core</artifactId>

--- a/discord-notifier-console-plugin/pom.xml
+++ b/discord-notifier-console-plugin/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise</version>
+        <version>1.2-enterprise-SNAPSHOT</version>
     </parent>
 
     <artifactId>discord-notifier-console-plugin</artifactId>

--- a/discord-notifier-console-plugin/pom.xml
+++ b/discord-notifier-console-plugin/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise-SNAPSHOT</version>
+        <version>1.1-enterprise</version>
     </parent>
 
     <artifactId>discord-notifier-console-plugin</artifactId>

--- a/discord-notifier-core/pom.xml
+++ b/discord-notifier-core/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise</version>
+        <version>1.2-enterprise-SNAPSHOT</version>
     </parent>
 
     <artifactId>discord-notifier-core</artifactId>

--- a/discord-notifier-core/pom.xml
+++ b/discord-notifier-core/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise-SNAPSHOT</version>
+        <version>1.1-enterprise</version>
     </parent>
 
     <artifactId>discord-notifier-core</artifactId>

--- a/email-notifier-console-plugin-l10n/pom.xml
+++ b/email-notifier-console-plugin-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise-SNAPSHOT</version>
+        <version>1.1-enterprise</version>
     </parent>
 
     <artifactId>email-notifier-console-plugin-l10n</artifactId>

--- a/email-notifier-console-plugin-l10n/pom.xml
+++ b/email-notifier-console-plugin-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise</version>
+        <version>1.2-enterprise-SNAPSHOT</version>
     </parent>
 
     <artifactId>email-notifier-console-plugin-l10n</artifactId>

--- a/email-notifier-console-plugin/pom.xml
+++ b/email-notifier-console-plugin/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise</version>
+        <version>1.2-enterprise-SNAPSHOT</version>
     </parent>
 
     <artifactId>email-notifier-console-plugin</artifactId>

--- a/email-notifier-console-plugin/pom.xml
+++ b/email-notifier-console-plugin/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise-SNAPSHOT</version>
+        <version>1.1-enterprise</version>
     </parent>
 
     <artifactId>email-notifier-console-plugin</artifactId>

--- a/email-notifier-core/pom.xml
+++ b/email-notifier-core/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise-SNAPSHOT</version>
+        <version>1.1-enterprise</version>
     </parent>
 
     <artifactId>email-notifier-core</artifactId>

--- a/email-notifier-core/pom.xml
+++ b/email-notifier-core/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise</version>
+        <version>1.2-enterprise-SNAPSHOT</version>
     </parent>
 
     <artifactId>email-notifier-core</artifactId>

--- a/enterprise-backwards-compatibility/pom.xml
+++ b/enterprise-backwards-compatibility/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <artifactId>notifiers-parent</artifactId>
         <groupId>fish.payara.extensions.notifiers</groupId>
-        <version>1.1-enterprise</version>
+        <version>1.2-enterprise-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/enterprise-backwards-compatibility/pom.xml
+++ b/enterprise-backwards-compatibility/pom.xml
@@ -44,11 +44,12 @@
     <parent>
         <artifactId>notifiers-parent</artifactId>
         <groupId>fish.payara.extensions.notifiers</groupId>
-        <version>1.1-enterprise-SNAPSHOT</version>
+        <version>1.1-enterprise</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>enterprise-backwards-compatibility</artifactId>
+    <version>1.1-enterprise-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Notifiers Backwards Compatibility Aggregator</name>

--- a/enterprise-backwards-compatibility/xmpp-notifier-backwards-compatibility/pom.xml
+++ b/enterprise-backwards-compatibility/xmpp-notifier-backwards-compatibility/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>fish.payara.extensions.notifiers</groupId>
             <artifactId>xmpp-notifier-core</artifactId>
-            <version>${project.version}</version>
+            <version>${payara-xmpp-notifier-core-plugin.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/example-notifier-console-plugin/pom.xml
+++ b/example-notifier-console-plugin/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise</version>
+        <version>1.2-enterprise-SNAPSHOT</version>
     </parent>
 
     <artifactId>example-notifier-console-plugin</artifactId>

--- a/example-notifier-console-plugin/pom.xml
+++ b/example-notifier-console-plugin/pom.xml
@@ -44,10 +44,11 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise-SNAPSHOT</version>
+        <version>1.1-enterprise</version>
     </parent>
 
     <artifactId>example-notifier-console-plugin</artifactId>
+    <version>1.1-enterprise-SNAPSHOT</version>
     <packaging>glassfish-jar</packaging>
 
     <name>Example Notifier Console Plugin</name>

--- a/example-notifier-core/pom.xml
+++ b/example-notifier-core/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise</version>
+        <version>1.2-enterprise-SNAPSHOT</version>
     </parent>
 
     <artifactId>example-notifier-core</artifactId>

--- a/example-notifier-core/pom.xml
+++ b/example-notifier-core/pom.xml
@@ -44,10 +44,11 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise-SNAPSHOT</version>
+        <version>1.1-enterprise</version>
     </parent>
 
     <artifactId>example-notifier-core</artifactId>
+    <version>1.1-enterprise-SNAPSHOT</version>
     <packaging>glassfish-jar</packaging>
 
     <name>Example Notifier Implementation</name>

--- a/newrelic-notifier-console-plugin-l10n/pom.xml
+++ b/newrelic-notifier-console-plugin-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise</version>
+        <version>1.2-enterprise-SNAPSHOT</version>
     </parent>
 
     <artifactId>newrelic-notifier-console-plugin-l10n</artifactId>

--- a/newrelic-notifier-console-plugin-l10n/pom.xml
+++ b/newrelic-notifier-console-plugin-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise-SNAPSHOT</version>
+        <version>1.1-enterprise</version>
     </parent>
 
     <artifactId>newrelic-notifier-console-plugin-l10n</artifactId>

--- a/newrelic-notifier-console-plugin/pom.xml
+++ b/newrelic-notifier-console-plugin/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise</version>
+        <version>1.2-enterprise-SNAPSHOT</version>
     </parent>
 
     <artifactId>newrelic-notifier-console-plugin</artifactId>

--- a/newrelic-notifier-console-plugin/pom.xml
+++ b/newrelic-notifier-console-plugin/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise-SNAPSHOT</version>
+        <version>1.1-enterprise</version>
     </parent>
 
     <artifactId>newrelic-notifier-console-plugin</artifactId>

--- a/newrelic-notifier-core/pom.xml
+++ b/newrelic-notifier-core/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise-SNAPSHOT</version>
+        <version>1.1-enterprise</version>
     </parent>
 
     <artifactId>newrelic-notifier-core</artifactId>

--- a/newrelic-notifier-core/pom.xml
+++ b/newrelic-notifier-core/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise</version>
+        <version>1.2-enterprise-SNAPSHOT</version>
     </parent>
 
     <artifactId>newrelic-notifier-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
     <groupId>fish.payara.extensions.notifiers</groupId>
     <artifactId>notifiers-parent</artifactId>
-    <version>1.1-enterprise</version>
+    <version>1.2-enterprise-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Payara Notifiers Parent</name>
@@ -56,7 +56,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <payara-xmpp-notifier-core-plugin.version>1.1-enterprise</payara-xmpp-notifier-core-plugin.version>
+        <payara-xmpp-notifier-core-plugin.version>1.2-enterprise-SNAPSHOT</payara-xmpp-notifier-core-plugin.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
     <groupId>fish.payara.extensions.notifiers</groupId>
     <artifactId>notifiers-parent</artifactId>
-    <version>1.1-enterprise-SNAPSHOT</version>
+    <version>1.1-enterprise</version>
     <packaging>pom</packaging>
 
     <name>Payara Notifiers Parent</name>
@@ -55,6 +55,8 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <payara-xmpp-notifier-core-plugin.version>1.1-enterprise</payara-xmpp-notifier-core-plugin.version>
     </properties>
 
     <modules>

--- a/slack-notifier-console-plugin-l10n/pom.xml
+++ b/slack-notifier-console-plugin-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise</version>
+        <version>1.2-enterprise-SNAPSHOT</version>
     </parent>
 
     <artifactId>slack-notifier-console-plugin-l10n</artifactId>

--- a/slack-notifier-console-plugin-l10n/pom.xml
+++ b/slack-notifier-console-plugin-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise-SNAPSHOT</version>
+        <version>1.1-enterprise</version>
     </parent>
 
     <artifactId>slack-notifier-console-plugin-l10n</artifactId>

--- a/slack-notifier-console-plugin/pom.xml
+++ b/slack-notifier-console-plugin/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise</version>
+        <version>1.2-enterprise-SNAPSHOT</version>
     </parent>
 
     <artifactId>slack-notifier-console-plugin</artifactId>

--- a/slack-notifier-console-plugin/pom.xml
+++ b/slack-notifier-console-plugin/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise-SNAPSHOT</version>
+        <version>1.1-enterprise</version>
     </parent>
 
     <artifactId>slack-notifier-console-plugin</artifactId>

--- a/slack-notifier-core/pom.xml
+++ b/slack-notifier-core/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise-SNAPSHOT</version>
+        <version>1.1-enterprise</version>
     </parent>
 
     <artifactId>slack-notifier-core</artifactId>

--- a/slack-notifier-core/pom.xml
+++ b/slack-notifier-core/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise</version>
+        <version>1.2-enterprise-SNAPSHOT</version>
     </parent>
 
     <artifactId>slack-notifier-core</artifactId>

--- a/snmp-notifier-console-plugin-l10n/pom.xml
+++ b/snmp-notifier-console-plugin-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise</version>
+        <version>1.2-enterprise-SNAPSHOT</version>
     </parent>
 
     <artifactId>snmp-notifier-console-plugin-l10n</artifactId>

--- a/snmp-notifier-console-plugin-l10n/pom.xml
+++ b/snmp-notifier-console-plugin-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise-SNAPSHOT</version>
+        <version>1.1-enterprise</version>
     </parent>
 
     <artifactId>snmp-notifier-console-plugin-l10n</artifactId>

--- a/snmp-notifier-console-plugin/pom.xml
+++ b/snmp-notifier-console-plugin/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise</version>
+        <version>1.2-enterprise-SNAPSHOT</version>
     </parent>
 
     <artifactId>snmp-notifier-console-plugin</artifactId>

--- a/snmp-notifier-console-plugin/pom.xml
+++ b/snmp-notifier-console-plugin/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise-SNAPSHOT</version>
+        <version>1.1-enterprise</version>
     </parent>
 
     <artifactId>snmp-notifier-console-plugin</artifactId>

--- a/snmp-notifier-core/pom.xml
+++ b/snmp-notifier-core/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise-SNAPSHOT</version>
+        <version>1.1-enterprise</version>
     </parent>
 
     <artifactId>snmp-notifier-core</artifactId>

--- a/snmp-notifier-core/pom.xml
+++ b/snmp-notifier-core/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise</version>
+        <version>1.2-enterprise-SNAPSHOT</version>
     </parent>
 
     <artifactId>snmp-notifier-core</artifactId>

--- a/teams-notifier-console-plugin/pom.xml
+++ b/teams-notifier-console-plugin/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise</version>
+        <version>1.2-enterprise-SNAPSHOT</version>
     </parent>
 
     <artifactId>teams-notifier-console-plugin</artifactId>

--- a/teams-notifier-console-plugin/pom.xml
+++ b/teams-notifier-console-plugin/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise-SNAPSHOT</version>
+        <version>1.1-enterprise</version>
     </parent>
 
     <artifactId>teams-notifier-console-plugin</artifactId>

--- a/teams-notifier-core/pom.xml
+++ b/teams-notifier-core/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise-SNAPSHOT</version>
+        <version>1.1-enterprise</version>
     </parent>
 
     <artifactId>teams-notifier-core</artifactId>

--- a/teams-notifier-core/pom.xml
+++ b/teams-notifier-core/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise</version>
+        <version>1.2-enterprise-SNAPSHOT</version>
     </parent>
 
     <artifactId>teams-notifier-core</artifactId>

--- a/xmpp-notifier-console-plugin-l10n/pom.xml
+++ b/xmpp-notifier-console-plugin-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise</version>
+        <version>1.2-enterprise-SNAPSHOT</version>
     </parent>
 
     <artifactId>xmpp-notifier-console-plugin-l10n</artifactId>

--- a/xmpp-notifier-console-plugin-l10n/pom.xml
+++ b/xmpp-notifier-console-plugin-l10n/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise-SNAPSHOT</version>
+        <version>1.1-enterprise</version>
     </parent>
 
     <artifactId>xmpp-notifier-console-plugin-l10n</artifactId>

--- a/xmpp-notifier-console-plugin/pom.xml
+++ b/xmpp-notifier-console-plugin/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise</version>
+        <version>1.2-enterprise-SNAPSHOT</version>
     </parent>
 
     <artifactId>xmpp-notifier-console-plugin</artifactId>

--- a/xmpp-notifier-console-plugin/pom.xml
+++ b/xmpp-notifier-console-plugin/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise-SNAPSHOT</version>
+        <version>1.1-enterprise</version>
     </parent>
 
     <artifactId>xmpp-notifier-console-plugin</artifactId>

--- a/xmpp-notifier-core/pom.xml
+++ b/xmpp-notifier-core/pom.xml
@@ -44,11 +44,11 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise-SNAPSHOT</version>
+        <version>1.1-enterprise</version>
     </parent>
 
     <artifactId>xmpp-notifier-core</artifactId>
-    <version>1.1-enterprise-SNAPSHOT</version>
+    <version>1.1-enterprise</version>
     <packaging>glassfish-jar</packaging>
 
     <name>XMPP Notifier Implementation</name>

--- a/xmpp-notifier-core/pom.xml
+++ b/xmpp-notifier-core/pom.xml
@@ -44,11 +44,11 @@
     <parent>
         <groupId>fish.payara.extensions.notifiers</groupId>
         <artifactId>notifiers-parent</artifactId>
-        <version>1.1-enterprise</version>
+        <version>1.2-enterprise-SNAPSHOT</version>
     </parent>
 
     <artifactId>xmpp-notifier-core</artifactId>
-    <version>1.1-enterprise</version>
+    <version>1.2-enterprise-SNAPSHOT</version>
     <packaging>glassfish-jar</packaging>
 
     <name>XMPP Notifier Implementation</name>


### PR DESCRIPTION
Fixed version of https://github.com/payara/Notifiers/pull/25
Parent pom needs to point at correct version (it's not a dependency when compiling)