### PR TITLE
Fish-7168 (Enterprise) Use SNMP4j 3.7.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ target/
 .factorypath
 .vscode/
 *.iml
+.idea/

--- a/snmp-notifier-core/pom.xml
+++ b/snmp-notifier-core/pom.xml
@@ -54,7 +54,7 @@
     <name>SNMP Notifier Implementation</name>
     
     <properties>
-        <snmp4j.version>3.4.3</snmp4j.version>
+        <snmp4j.version>3.7.5</snmp4j.version>
     </properties>
 
     <dependencies>

--- a/snmp-notifier-core/pom.xml
+++ b/snmp-notifier-core/pom.xml
@@ -69,13 +69,4 @@
             <version>${snmp4j.version}</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <!-- Required to copy dependencies into target directory -->
-            <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 </project>


### PR DESCRIPTION
Use SNMP4j 3.7.5. Removed the dependency plugin as it would add snmp4j-3.7.5 to the target directory which is not helpful as it's not compatible with Payara (Due to it not being OSGi-ified) instead it's repackaged in Payara.

Tested the admin console loads, the snmp page looks correct, the `get-snmp-notifier-configuration` and `set-snmp-notifier-configuration` commands work.