### PR TITLE
FISH-7165 FISH-7166 FISH-7167 Upgrade JXMPP, Smack and MiniDNS

### DIFF
--- a/xmpp-notifier-core/pom.xml
+++ b/xmpp-notifier-core/pom.xml
@@ -57,6 +57,7 @@
         <smack.version>4.3.4</smack.version>
         <xpp3.version>1.1.4c_7</xpp3.version>
         <jxmpp.version>1.0.3</jxmpp.version>
+        <minidns.version>1.0.4</minidns.version>
     </properties>
 
     <dependencies>
@@ -137,6 +138,11 @@
                                     <groupId>org.jxmpp</groupId>
                                     <artifactId>jxmpp-util-cache</artifactId>
                                     <version>${jxmpp.version}</version>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.minidns</groupId>
+                                    <artifactId>minidns-core</artifactId>
+                                    <version>${minidns.version}</version>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/xmpp-notifier-core/pom.xml
+++ b/xmpp-notifier-core/pom.xml
@@ -54,7 +54,7 @@
     <name>XMPP Notifier Implementation</name>
 
     <properties>
-        <smack.version>4.3.4</smack.version>
+        <smack.version>4.4.6</smack.version>
         <xpp3.version>1.1.4c_7</xpp3.version>
         <jxmpp.version>1.0.3</jxmpp.version>
         <minidns.version>1.0.4</minidns.version>
@@ -120,14 +120,44 @@
                                     <version>${smack.version}</version>
                                 </artifactItem>
                                 <artifactItem>
-                                    <groupId>org.apache.servicemix.bundles</groupId>
-                                    <artifactId>org.apache.servicemix.bundles.xpp3</artifactId>
-                                    <version>${xpp3.version}</version>
+                                    <groupId>org.igniterealtime.smack</groupId>
+                                    <artifactId>smack-java8</artifactId>
+                                    <version>${smack.version}</version>
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>org.igniterealtime.smack</groupId>
-                                    <artifactId>smack-java7</artifactId>
+                                    <artifactId>smack-core</artifactId>
                                     <version>${smack.version}</version>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.igniterealtime.smack</groupId>
+                                    <artifactId>smack-xmlparser</artifactId>
+                                    <version>${smack.version}</version>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.igniterealtime.smack</groupId>
+                                    <artifactId>smack-im</artifactId>
+                                    <version>${smack.version}</version>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.igniterealtime.smack</groupId>
+                                    <artifactId>smack-streammanagement</artifactId>
+                                    <version>${smack.version}</version>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.igniterealtime.smack</groupId>
+                                    <artifactId>smack-xmlparser-stax</artifactId>
+                                    <version>${smack.version}</version>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.aries.spifly</groupId>
+                                    <artifactId>org.apache.aries.spifly.dynamic.bundle</artifactId>
+                                    <version>1.3.6</version>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.servicemix.bundles</groupId>
+                                    <artifactId>org.apache.servicemix.bundles.xpp3</artifactId>
+                                    <version>${xpp3.version}</version>
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>org.jxmpp</groupId>

--- a/xmpp-notifier-core/pom.xml
+++ b/xmpp-notifier-core/pom.xml
@@ -56,6 +56,7 @@
     <properties>
         <smack.version>4.3.4</smack.version>
         <xpp3.version>1.1.4c_7</xpp3.version>
+        <jxmpp.version>1.0.3</jxmpp.version>
     </properties>
 
     <dependencies>
@@ -82,6 +83,11 @@
             <groupId>org.igniterealtime.smack</groupId>
             <artifactId>smack-extensions</artifactId>
             <version>${smack.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jxmpp</groupId>
+            <artifactId>jxmpp-jid</artifactId>
+            <version>${jxmpp.version}</version>
         </dependency>
     </dependencies>
 
@@ -121,6 +127,16 @@
                                     <groupId>org.igniterealtime.smack</groupId>
                                     <artifactId>smack-java7</artifactId>
                                     <version>${smack.version}</version>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.jxmpp</groupId>
+                                    <artifactId>jxmpp-core</artifactId>
+                                    <version>${jxmpp.version}</version>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.jxmpp</groupId>
+                                    <artifactId>jxmpp-util-cache</artifactId>
+                                    <version>${jxmpp.version}</version>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/xmpp-notifier-core/pom.xml
+++ b/xmpp-notifier-core/pom.xml
@@ -67,13 +67,6 @@
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
         </dependency>
-
-        <!-- Extra dependencies. Need copying into modules directory -->
-        <dependency>
-            <groupId>org.igniterealtime.smack</groupId>
-            <artifactId>smack-java7</artifactId>
-            <version>${smack.version}</version>
-        </dependency>
         <dependency>
             <groupId>org.igniterealtime.smack</groupId>
             <artifactId>smack-tcp</artifactId>
@@ -90,23 +83,49 @@
             <artifactId>smack-extensions</artifactId>
             <version>${smack.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.igniterealtime.smack</groupId>
-            <artifactId>smack-im</artifactId>
-            <version>${smack.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.servicemix.bundles</groupId>
-            <artifactId>org.apache.servicemix.bundles.xpp3</artifactId>
-            <version>${xpp3.version}</version>
-        </dependency>
     </dependencies>
 
     <build>
         <plugins>
             <!-- Required to copy dependencies into target directory -->
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <!--
+                        Copy any additional dependencies required for xmpp-notifier-core to work in Payara into
+                        the target dir
+                        The project dependencies will be included automatically as part of the default copy-dependencies
+                        phase therefore they don't need to be included here.
+                    -->
+                    <execution>
+                        <id>copy</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.igniterealtime.smack</groupId>
+                                    <artifactId>smack-im</artifactId>
+                                    <version>${smack.version}</version>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.servicemix.bundles</groupId>
+                                    <artifactId>org.apache.servicemix.bundles.xpp3</artifactId>
+                                    <version>${xpp3.version}</version>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.igniterealtime.smack</groupId>
+                                    <artifactId>smack-java7</artifactId>
+                                    <version>${smack.version}</version>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
JXMPP and MiniDNS both require later versions of Smack hence a joint PR. 
- Updated JXMPP to 1.0.3
- Updated Smack to 4.4.6
- Updated MiniDNS to 1.0.4

I have also added a full config for the maven-dependency-plugin. This notifier requires additional dependencies, originally this plugin was used to add the dependencies to the target directory as they are required, however it didn't add all of the required files. I have changed this out to use Artifact-Items and include all required dependencies for use in Payara.