### PR TITLE
FISH-9694 Event Filtering For Enterprise5 Extensions

### DIFF
--- a/datadog-notifier-console-plugin/src/main/resources/datadog/datadogNotifierConfiguration.jsf
+++ b/datadog-notifier-console-plugin/src/main/resources/datadog/datadogNotifierConfiguration.jsf
@@ -108,6 +108,11 @@ holder.
                           helpText="$resource{i18nn.notification.configuration.notifier.dynamicHelp}">
                 <sun:checkbox id="dynamic" selected="#{pageSession.dynamic}" selectedValue="true" />
             </sun:property>
+            <sun:property id="filter" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"
+                          label="$resource{i18nn.notification.configuration.filter}"
+                          helpText="$resource{i18nn.notification.configuration.notifier.filterHelp}">
+                <sun:dropDown id="filterDropdown" selected="#{pageSession.valueMap['filter']}" labels={"INFO", "WARNING", "SEVERE"} />
+            </sun:property>
             <sun:property id="keyProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"
                           label="$resource{i18ndn.notifier.datadog.configuration.keyLabel}"
                           helpText="$resource{i18ndn.notifier.datadog.configuration.keyLabelHelpText}">

--- a/discord-notifier-console-plugin/src/main/resources/discord/discordNotifierConfiguration.jsf
+++ b/discord-notifier-console-plugin/src/main/resources/discord/discordNotifierConfiguration.jsf
@@ -107,6 +107,11 @@
                           helpText="$resource{i18nn.notification.configuration.notifier.dynamicHelp}">
                 <sun:checkbox id="dynamic" selected="#{pageSession.dynamic}" selectedValue="true" />
             </sun:property>
+            <sun:property id="filter" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"
+                          label="$resource{i18nn.notification.configuration.filter}"
+                          helpText="$resource{i18nn.notification.configuration.notifier.filterHelp}">
+                <sun:dropDown id="filterDropdown" selected="#{pageSession.valueMap['filter']}" labels={"INFO", "WARNING", "SEVERE"} />
+            </sun:property>
             <sun:property id="webhookIdProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"
                           label="$resource{i18nexn.notifier.discord.configuration.webhookIdLabel}"
                           helpText="$resource{i18nexn.notifier.discord.configuration.webhookIdLabelHelpText}">

--- a/email-notifier-console-plugin/src/main/resources/email/emailNotifierConfiguration.jsf
+++ b/email-notifier-console-plugin/src/main/resources/email/emailNotifierConfiguration.jsf
@@ -105,6 +105,11 @@ holder.
                           helpText="$resource{i18nn.notification.configuration.notifier.dynamicHelp}">
                 <sun:checkbox id="dynamic" selected="#{pageSession.dynamic}" selectedValue="true" />
             </sun:property>
+            <sun:property id="filter" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"
+                          label="$resource{i18nn.notification.configuration.filter}"
+                          helpText="$resource{i18nn.notification.configuration.notifier.filterHelp}">
+                <sun:dropDown id="filterDropdown" selected="#{pageSession.valueMap['filter']}" labels={"INFO", "WARNING", "SEVERE"} />
+            </sun:property>
             <sun:property id="jndiNameProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" 
                           label="$resource{i18nemn.notifier.email.configuration.jndiNameLabel}"  
                           helpText="$resource{i18nemn.notifier.email.configuration.jndiNameLabelHelpText}">

--- a/example-notifier-console-plugin/src/main/resources/example/exampleNotifierConfiguration.jsf
+++ b/example-notifier-console-plugin/src/main/resources/example/exampleNotifierConfiguration.jsf
@@ -107,6 +107,11 @@
                           helpText="$resource{i18nn.notification.configuration.notifier.dynamicHelp}">
                 <sun:checkbox id="dynamic" selected="#{pageSession.dynamic}" selectedValue="true" />
             </sun:property>
+            <sun:property id="filter" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"
+                          label="$resource{i18nn.notification.configuration.filter}"
+                          helpText="$resource{i18nn.notification.configuration.notifier.filterHelp}">
+                <sun:dropDown id="filterDropdown" selected="#{pageSession.valueMap['filter']}" labels={"INFO", "WARNING", "SEVERE"} />
+            </sun:property>
             <sun:property id="testValueProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"
                           label="$resource{i18nexn.notifier.example.configuration.testValueLabel}"
                           helpText="$resource{i18nexn.notifier.example.configuration.testValueLabelHelpText}">

--- a/newrelic-notifier-console-plugin/src/main/resources/newrelic/newRelicNotifierConfiguration.jsf
+++ b/newrelic-notifier-console-plugin/src/main/resources/newrelic/newRelicNotifierConfiguration.jsf
@@ -106,6 +106,11 @@ holder.
                           helpText="$resource{i18nn.notification.configuration.notifier.dynamicHelp}">
                 <sun:checkbox id="dynamic" selected="#{pageSession.dynamic}" selectedValue="true" />
             </sun:property>
+            <sun:property id="filter" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"
+                          label="$resource{i18nn.notification.configuration.filter}"
+                          helpText="$resource{i18nn.notification.configuration.notifier.filterHelp}">
+                <sun:dropDown id="filterDropdown" selected="#{pageSession.valueMap['filter']}" labels={"INFO", "WARNING", "SEVERE"} />
+            </sun:property>
             <sun:property id="keyProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"
                           label="$resource{i18nrn.notifier.newrelic.configuration.keyLabel}"
                           helpText="$resource{i18nrn.notifier.newrelic.configuration.keyLabelHelpText}">

--- a/slack-notifier-console-plugin/src/main/resources/slack/slackNotifierConfiguration.jsf
+++ b/slack-notifier-console-plugin/src/main/resources/slack/slackNotifierConfiguration.jsf
@@ -106,6 +106,11 @@ holder.
                           helpText="$resource{i18nn.notification.configuration.notifier.dynamicHelp}">
                 <sun:checkbox id="dynamic" selected="#{pageSession.dynamic}" selectedValue="true" />
             </sun:property>
+            <sun:property id="filter" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"
+                          label="$resource{i18nn.notification.configuration.filter}"
+                          helpText="$resource{i18nn.notification.configuration.notifier.filterHelp}">
+                <sun:dropDown id="filterDropdown" selected="#{pageSession.valueMap['filter']}" labels={"INFO", "WARNING", "SEVERE"} />
+            </sun:property>
             <sun:property id="token1Prop" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" 
                           label="$resource{i18nsn.notifier.slack.configuration.token1Label}"  
                           helpText="$resource{i18nsn.notifier.slack.configuration.token1LabelHelpText}">

--- a/snmp-notifier-console-plugin/src/main/resources/snmp/SNMPNotifierConfiguration.jsf
+++ b/snmp-notifier-console-plugin/src/main/resources/snmp/SNMPNotifierConfiguration.jsf
@@ -105,6 +105,11 @@ holder.
                           helpText="$resource{i18nsnn.notifier.snmp.configuration.dynamicLabelHelpText}">
                 <sun:checkbox id="dynamicProp" selected="#{pageSession.dynamicSelected}" selectedValue="true" />
             </sun:property>
+            <sun:property id="filter" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"
+                          label="$resource{i18nn.notification.configuration.filter}"
+                          helpText="$resource{i18nn.notification.configuration.notifier.filterHelp}">
+                <sun:dropDown id="filterDropdown" selected="#{pageSession.valueMap['filter']}" labels={"INFO", "WARNING", "SEVERE"} />
+            </sun:property>
             <sun:property id="communityProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" 
                           label="$resource{i18nsnn.notifier.snmp.configuration.communityLabel}"  
                           helpText="$resource{i18nsnn.notifier.snmp.configuration.communityLabelHelpText}">

--- a/teams-notifier-console-plugin/src/main/resources/teams/teamsNotifierConfiguration.jsf
+++ b/teams-notifier-console-plugin/src/main/resources/teams/teamsNotifierConfiguration.jsf
@@ -107,6 +107,11 @@ holder.
                           helpText="$resource{i18nn.notification.configuration.notifier.dynamicHelp}">
                 <sun:checkbox id="dynamic" selected="#{pageSession.dynamic}" selectedValue="true" />
             </sun:property>
+            <sun:property id="filter" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"
+                          label="$resource{i18nn.notification.configuration.filter}"
+                          helpText="$resource{i18nn.notification.configuration.notifier.filterHelp}">
+                <sun:dropDown id="filterDropdown" selected="#{pageSession.valueMap['filter']}" labels={"INFO", "WARNING", "SEVERE"} />
+            </sun:property>
             <sun:property id="webhookUrlProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" 
                           label="$resource{i18nemn.notifier.teams.configuration.webhookUrlLabel}"  
                           helpText="$resource{i18nemn.notifier.teams.configuration.webhookUrlLabelHelpText}">

--- a/xmpp-notifier-console-plugin/src/main/resources/xmpp/xmppNotifierConfiguration.jsf
+++ b/xmpp-notifier-console-plugin/src/main/resources/xmpp/xmppNotifierConfiguration.jsf
@@ -112,6 +112,11 @@ holder.
                           helpText="$resource{i18nn.notification.configuration.notifier.dynamicHelp}">
                 <sun:checkbox id="dynamicBox" selected="#{pageSession.dynamic}" selectedValue="true" />
             </sun:property>
+            <sun:property id="filter" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"
+                          label="$resource{i18nn.notification.configuration.filter}"
+                          helpText="$resource{i18nn.notification.configuration.notifier.filterHelp}">
+                <sun:dropDown id="filterDropdown" selected="#{pageSession.valueMap['filter']}" labels={"INFO", "WARNING", "SEVERE"} />
+            </sun:property>
             <sun:property id="hostNameProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" 
                           label="$resource{i18nxn.notifier.xmpp.configuration.hostNameLabel}"  
                           helpText="$resource{i18nxn.notifier.xmpp.configuration.hostNameLabelHelpText}">


### PR DESCRIPTION
Adds a dropdown in the Admin Console to select the event level for extension notifiers;

Tested successfully as part of [FISH-9693 for Enterprise 5](https://github.com/payara/Payara-Enterprise/pull/1641).