### PR TITLE
FISH-10032 Teams Notifier Admin Console (Enterprise5)

### DIFF
--- a/teams-notifier-console-plugin/src/main/resources/teams/teamsNotifierConfiguration.jsf
+++ b/teams-notifier-console-plugin/src/main/resources/teams/teamsNotifierConfiguration.jsf
@@ -45,7 +45,7 @@ holder.
 <!define name="content">
 <event>
     <!beforeCreate
-        setPageSessionAttribute(key="onlyUseAttrs", value={"id", "enabled", "dynamic", "target"});
+        setPageSessionAttribute(key="onlyUseAttrs", value={"id", "enabled", "dynamic", "filter", "target"});
         getRequestValue(key="configName" value="#{pageSession.configName}" );
         createMap(result="#{pageSession.attrsMap}")
         mapPut(map="#{pageSession.attrsMap}" key="target" value="#{pageSession.configName}");


### PR DESCRIPTION
Makes the drop-down menu for filtering work for the Teams notifier.