### PR TITLE
FISH-10016 Upgrade SNMP4J (Enterprise5)

### DIFF
--- a/snmp-notifier-core/pom.xml
+++ b/snmp-notifier-core/pom.xml
@@ -2,7 +2,7 @@
 <!--
   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-  Copyright (c) 2020-202 Payara Foundation and/or its affiliates. All rights reserved.
+  Copyright (c) 2020-2024 Payara Foundation and/or its affiliates. All rights reserved.
 
   The contents of this file are subject to the terms of either the GNU
   General Public License Version 2 only ("GPL") or the Common Development
@@ -52,21 +52,16 @@
     <packaging>glassfish-jar</packaging>
 
     <name>SNMP Notifier Implementation</name>
-    
-    <properties>
-        <snmp4j.version>3.4.3</snmp4j.version>
-    </properties>
 
     <dependencies>
         <dependency>
             <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
         </dependency>
-        
         <dependency>
-            <groupId>org.snmp4j</groupId>
-            <artifactId>snmp4j</artifactId>
-            <version>${snmp4j.version}</version>
+            <groupId>fish.payara.server.internal.packager</groupId>
+            <artifactId>snmp4j-repackaged</artifactId>
+            <version>${payara.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Changes the SNMP4J version to use the repackaged jar from Enterprise5.